### PR TITLE
Add tag deletion for admin accounts

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -19,6 +19,8 @@ export const Login = ({ setToken }) => {
     loginUser(user).then(res => {
       if ("valid" in res && res.valid) {
         setToken(res.token)
+        localStorage.setItem("token", res.token)
+        localStorage.setItem("is_admin", res.is_admin)
         navigate("/")
       }
       else {

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -31,6 +31,7 @@ export const Register = ({setToken}) => {
         .then(res => {
           if ("valid" in res && res.valid) {
             setToken(res.token)
+            localStorage.setItem("is_admin", res.is_admin)
             navigate("/")
           }
         })

--- a/src/components/tag/TagList.jsx
+++ b/src/components/tag/TagList.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom"
-import { getAllTags } from "../../managers/tagManager";
+import { deleteTag, getAllTags } from "../../managers/tagManager";
 
 export const TagList = () => {
     const navigate = useNavigate();
     const [tags, setTags] = useState([]);
+
+    const isAdmin = localStorage.getItem("is_admin") === "1"
 
         useEffect(() => {
             getAllTags().then((tagData) => {
@@ -14,6 +16,16 @@ export const TagList = () => {
 
     const tagForm = () => {
         navigate("/newtag")
+    }
+
+    const handleDelete = (tagId) => {
+        const confirmDelete = window.confirm("Are you sure you want to delete this tag?")
+
+        if (confirmDelete) {
+            deleteTag(tagId).then(() => {
+                getAllTags().then(setTags)
+            })
+        }
     }
     
     return (
@@ -25,11 +37,15 @@ export const TagList = () => {
                             tags.map(tag => {
                                 return <section key={`tag${tag.id}`} className="tag">
                                     <div className="tag-label">{tag.label}</div>
+                                    {isAdmin && (
+                                        <button onClick={() => handleDelete(tag.id)}>Delete</button>
+                                    )}
                                 </section>
                             })
                         }
                 </div>
             <button onClick={tagForm}>Create Tag</button>
+            
         </div>
     )
 }

--- a/src/managers/tagManager.js
+++ b/src/managers/tagManager.js
@@ -14,3 +14,12 @@ export const createTag = (tagObject) => {
     })
     .then((res) => res.json())    
 }
+
+export const deleteTag = (tagId) => {
+    return fetch(`http://localhost:8088/tags/${tagId}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("token")}`
+        }
+    })
+}


### PR DESCRIPTION
# Description

Tag Management
Conditionally render Delete button only for admin users
Added confirmation window before tag deletion
Refresh tag list after deletion

Authentication
Store token in localStorage when user is logged in
Store is_admin in localStorage

Created deleteTag fetch request

## Changes

- [ ] Bug fix  
- [x] New feature  

## Testing

Verified admin can delete tags
Verified non-admin users do not see delete controls

## Notes

Anything else worth mentioning?

